### PR TITLE
final optimization trials

### DIFF
--- a/src/custom/SoftmaxKernel.ts
+++ b/src/custom/SoftmaxKernel.ts
@@ -6,13 +6,13 @@
 import { KernelSpec } from '../kernel';
 
 /**
- * Fused softmax kernel for any dimension
+ * Fused softmax kernel for any dimension - Level 4 (Subgroup Operations)
+ * Uses WebGPU subgroup operations for warp-level reductions
  */
-
 export const softmaxKernel: KernelSpec = {
   name: "softmax_dim",
   config: [
-    { name: "numThreads" }
+    { name: "numSlices" }
   ],
   parameters: [
     { name: "ndim", shaderType: "u32" },
@@ -35,137 +35,184 @@ export const softmaxKernel: KernelSpec = {
   ],
   workgroupSize: [256, 1, 1],
   workgroupCount: [
-    "(numThreads + 255) / 256",
+    "numSlices",
     1,
     1
   ],
-  workgroupVariables: [],
+  // Minimal shared memory - only need storage for cross-subgroup reductions
+  workgroupVariables: [
+    { name: "sharedMax", shaderType: ["array<f32>", 8] },  // One per subgroup (256/32 = 8)
+    { name: "sharedSum", shaderType: ["array<f32>", 8] }
+  ],
   shader: `
-    let stride4 = 1u;
-    let stride3 = parameters.D4;
-    let stride2 = parameters.D3 * parameters.D4;
-    let stride1 = parameters.D2 * parameters.D3 * parameters.D4;
-    let stride0 = parameters.D1 * parameters.D2 * parameters.D3 * parameters.D4;
+// Level 4: Subgroup operations (warp-level primitives)
+let stride4 = 1u;
+let stride3 = parameters.D4;
+let stride2 = parameters.D3 * parameters.D4;
+let stride1 = parameters.D2 * parameters.D3 * parameters.D4;
+let stride0 = parameters.D1 * parameters.D2 * parameters.D3 * parameters.D4;
 
-    var reduceSize: u32;
-    if (parameters.reduceDim == 0u) {
-      reduceSize = parameters.D0;
-    } else if (parameters.reduceDim == 1u) {
-      reduceSize = parameters.D1;
-    } else if (parameters.reduceDim == 2u) {
-      reduceSize = parameters.D2;
-    } else if (parameters.reduceDim == 3u) {
-      reduceSize = parameters.D3;
-    } else {
-      reduceSize = parameters.D4;
+var reduceSize: u32;
+if (parameters.reduceDim == 0u) {
+  reduceSize = parameters.D0;
+} else if (parameters.reduceDim == 1u) {
+  reduceSize = parameters.D1;
+} else if (parameters.reduceDim == 2u) {
+  reduceSize = parameters.D2;
+} else if (parameters.reduceDim == 3u) {
+  reduceSize = parameters.D3;
+} else {
+  reduceSize = parameters.D4;
+}
+
+// Each workgroup processes one slice (row)
+let sliceIdx = workgroup_id.x;  // Workgroup ID
+let tid = local_id.x;  // Thread ID within workgroup (0-255)
+let sg_id = subgroup_invocation_id;  // Thread ID within subgroup
+let sg_size = subgroup_size;  // Subgroup size (typically 32)
+let subgroup_idx = tid / sg_size;  // Which subgroup this thread belongs to
+
+// Decode slice index to coordinates
+var temp = sliceIdx;
+var d0 = 0u;
+var d1 = 0u;
+var d2 = 0u;
+var d3 = 0u;
+var d4 = 0u;
+
+if (parameters.reduceDim == 4u) {
+  d4 = 0u;
+  d3 = temp % parameters.D3; temp = temp / parameters.D3;
+  d2 = temp % parameters.D2; temp = temp / parameters.D2;
+  d1 = temp % parameters.D1; temp = temp / parameters.D1;
+  d0 = temp;
+} else if (parameters.reduceDim == 3u) {
+  d3 = 0u;
+  d4 = temp % parameters.D4; temp = temp / parameters.D4;
+  d2 = temp % parameters.D2; temp = temp / parameters.D2;
+  d1 = temp % parameters.D1; temp = temp / parameters.D1;
+  d0 = temp;
+} else if (parameters.reduceDim == 2u) {
+  d2 = 0u;
+  d4 = temp % parameters.D4; temp = temp / parameters.D4;
+  d3 = temp % parameters.D3; temp = temp / parameters.D3;
+  d1 = temp % parameters.D1; temp = temp / parameters.D1;
+  d0 = temp;
+} else if (parameters.reduceDim == 1u) {
+  d1 = 0u;
+  d4 = temp % parameters.D4; temp = temp / parameters.D4;
+  d3 = temp % parameters.D3; temp = temp / parameters.D3;
+  d2 = temp % parameters.D2; temp = temp / parameters.D2;
+  d0 = temp;
+} else {  // parameters.reduceDim == 0
+  d0 = 0u;
+  d4 = temp % parameters.D4; temp = temp / parameters.D4;
+  d3 = temp % parameters.D3; temp = temp / parameters.D3;
+  d2 = temp % parameters.D2; temp = temp / parameters.D2;
+  d1 = temp;
+}
+
+// ===== STEP 1: Find maximum value =====
+// Each thread computes local max for its chunk
+var localMax = -3.402823e+38;  // -FLT_MAX
+for (var i = tid; i < reduceSize; i = i + 256u) {
+  var idx_d0 = d0;
+  var idx_d1 = d1;
+  var idx_d2 = d2;
+  var idx_d3 = d3;
+  var idx_d4 = d4;
+
+  if (parameters.reduceDim == 0u) { idx_d0 = i; }
+  else if (parameters.reduceDim == 1u) { idx_d1 = i; }
+  else if (parameters.reduceDim == 2u) { idx_d2 = i; }
+  else if (parameters.reduceDim == 3u) { idx_d3 = i; }
+  else { idx_d4 = i; }
+
+  let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
+  let val = input[flatIdx];
+  if (val > localMax) {
+    localMax = val;
+  }
+}
+
+// Warp-level reduction using subgroup operations
+// subgroupMax reduces within the subgroup in O(log subgroup_size) steps
+let subgroupMaxVal = subgroupMax(localMax);
+
+// Store subgroup result to shared memory (only first thread in each subgroup writes)
+if (sg_id == 0u) {
+  sharedMax[subgroup_idx] = subgroupMaxVal;
+}
+workgroupBarrier();
+
+// Final reduction across subgroups (typically 8 subgroups in a 256-thread workgroup)
+var maxVal = sharedMax[0];
+if (tid < 8u) {
+  for (var j = 1u; j < 8u; j = j + 1u) {
+    if (sharedMax[j] > maxVal) {
+      maxVal = sharedMax[j];
     }
+  }
+}
+// Broadcast global max to all threads
+maxVal = subgroupBroadcast(maxVal, 0u);
+workgroupBarrier();
 
-    let totalSize = parameters.D0 * parameters.D1 * parameters.D2 * parameters.D3 * parameters.D4;
-    let numSlices = totalSize / reduceSize;
+// ===== STEP 2: Compute sum of exp(x - max) =====
+var localSum = 0.0;
+for (var i = tid; i < reduceSize; i = i + 256u) {
+  var idx_d0 = d0;
+  var idx_d1 = d1;
+  var idx_d2 = d2;
+  var idx_d3 = d3;
+  var idx_d4 = d4;
 
-    let sliceIdx = global_id.x;
+  if (parameters.reduceDim == 0u) { idx_d0 = i; }
+  else if (parameters.reduceDim == 1u) { idx_d1 = i; }
+  else if (parameters.reduceDim == 2u) { idx_d2 = i; }
+  else if (parameters.reduceDim == 3u) { idx_d3 = i; }
+  else { idx_d4 = i; }
 
-    if (sliceIdx >= numSlices) {
-      return;
-    }
+  let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
+  localSum = localSum + exp(input[flatIdx] - maxVal);
+}
 
-    var temp = sliceIdx;
-    var d0 = 0u;
-    var d1 = 0u;
-    var d2 = 0u;
-    var d3 = 0u;
-    var d4 = 0u;
+// Warp-level reduction using subgroup operations
+let subgroupSumVal = subgroupAdd(localSum);
 
-    if (parameters.reduceDim == 4u) {
-      d4 = 0u;
-      d3 = temp % parameters.D3; temp = temp / parameters.D3;
-      d2 = temp % parameters.D2; temp = temp / parameters.D2;
-      d1 = temp % parameters.D1; temp = temp / parameters.D1;
-      d0 = temp;
-    } else if (parameters.reduceDim == 3u) {
-      d3 = 0u;
-      d4 = temp % parameters.D4; temp = temp / parameters.D4;
-      d2 = temp % parameters.D2; temp = temp / parameters.D2;
-      d1 = temp % parameters.D1; temp = temp / parameters.D1;
-      d0 = temp;
-    } else if (parameters.reduceDim == 2u) {
-      d2 = 0u;
-      d4 = temp % parameters.D4; temp = temp / parameters.D4;
-      d3 = temp % parameters.D3; temp = temp / parameters.D3;
-      d1 = temp % parameters.D1; temp = temp / parameters.D1;
-      d0 = temp;
-    } else if (parameters.reduceDim == 1u) {
-      d1 = 0u;
-      d4 = temp % parameters.D4; temp = temp / parameters.D4;
-      d3 = temp % parameters.D3; temp = temp / parameters.D3;
-      d2 = temp % parameters.D2; temp = temp / parameters.D2;
-      d0 = temp;
-    } else {  // parameters.reduceDim == 0
-      d0 = 0u;
-      d4 = temp % parameters.D4; temp = temp / parameters.D4;
-      d3 = temp % parameters.D3; temp = temp / parameters.D3;
-      d2 = temp % parameters.D2; temp = temp / parameters.D2;
-      d1 = temp;
-    }
+// Store subgroup result to shared memory
+if (sg_id == 0u) {
+  sharedSum[subgroup_idx] = subgroupSumVal;
+}
+workgroupBarrier();
 
-    // Find max value along reduction dimension
-    var maxVal = -3.402823e+38;  // -FLT_MAX
-    for (var i = 0u; i < reduceSize; i = i + 1u) {
-      // Set the reduction dimension coordinate
-      var idx_d0 = d0;
-      var idx_d1 = d1;
-      var idx_d2 = d2;
-      var idx_d3 = d3;
-      var idx_d4 = d4;
+// Final reduction across subgroups
+var sumExp = 0.0;
+if (tid < 8u) {
+  for (var j = 0u; j < 8u; j = j + 1u) {
+    sumExp = sumExp + sharedSum[j];
+  }
+}
+// Broadcast global sum to all threads
+sumExp = subgroupBroadcast(sumExp, 0u);
+workgroupBarrier();
 
-      if (parameters.reduceDim == 0u) { idx_d0 = i; }
-      else if (parameters.reduceDim == 1u) { idx_d1 = i; }
-      else if (parameters.reduceDim == 2u) { idx_d2 = i; }
-      else if (parameters.reduceDim == 3u) { idx_d3 = i; }
-      else { idx_d4 = i; }
+// ===== STEP 3: Write normalized output =====
+for (var i = tid; i < reduceSize; i = i + 256u) {
+  var idx_d0 = d0;
+  var idx_d1 = d1;
+  var idx_d2 = d2;
+  var idx_d3 = d3;
+  var idx_d4 = d4;
 
-      let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
-      let val = input[flatIdx];
-      if (val > maxVal) {
-        maxVal = val;
-      }
-    }
+  if (parameters.reduceDim == 0u) { idx_d0 = i; }
+  else if (parameters.reduceDim == 1u) { idx_d1 = i; }
+  else if (parameters.reduceDim == 2u) { idx_d2 = i; }
+  else if (parameters.reduceDim == 3u) { idx_d3 = i; }
+  else { idx_d4 = i; }
 
-    // Compute sum of exp(x - max)
-    var sumExp = 0.0;
-    for (var i = 0u; i < reduceSize; i = i + 1u) {
-      var idx_d0 = d0;
-      var idx_d1 = d1;
-      var idx_d2 = d2;
-      var idx_d3 = d3;
-      var idx_d4 = d4;
-
-      if (parameters.reduceDim == 0u) { idx_d0 = i; }
-      else if (parameters.reduceDim == 1u) { idx_d1 = i; }
-      else if (parameters.reduceDim == 2u) { idx_d2 = i; }
-      else if (parameters.reduceDim == 3u) { idx_d3 = i; }
-      else { idx_d4 = i; }
-
-      let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
-      sumExp = sumExp + exp(input[flatIdx] - maxVal);
-    }
-
-    // Compute and write output: exp(x - max) / sumExp
-    for (var i = 0u; i < reduceSize; i = i + 1u) {
-      var idx_d0 = d0;
-      var idx_d1 = d1;
-      var idx_d2 = d2;
-      var idx_d3 = d3;
-      var idx_d4 = d4;
-
-      if (parameters.reduceDim == 0u) { idx_d0 = i; }
-      else if (parameters.reduceDim == 1u) { idx_d1 = i; }
-      else if (parameters.reduceDim == 2u) { idx_d2 = i; }
-      else if (parameters.reduceDim == 3u) { idx_d3 = i; }
-      else { idx_d4 = i; }
-
-      let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
-      output[flatIdx] = exp(input[flatIdx] - maxVal) / sumExp;
-    }
+  let flatIdx = idx_d0 * stride0 + idx_d1 * stride1 + idx_d2 * stride2 + idx_d3 * stride3 + idx_d4 * stride4;
+  output[flatIdx] = exp(input[flatIdx] - maxVal) / sumExp;
+}
   `
 };

--- a/src/devices.ts
+++ b/src/devices.ts
@@ -24,13 +24,24 @@ export async function discoverWebGPUDevicesAsync(): Promise<boolean> {
     const canTimestamp = adapter.features.has('timestamp-query');
     console.log(`[WebGPU] timestamp-query support: ${canTimestamp}`);
 
+    // Check if subgroups feature is supported
+    const canSubgroups = adapter.features.has('subgroups');
+    console.log(`[WebGPU] subgroups support: ${canSubgroups}`);
+
     console.log(`[WebGPU] Adapter limits:`, {
         maxBufferSize: `${(adapter.limits.maxBufferSize / 1024 / 1024).toFixed(2)} MB`,
         maxStorageBufferBindingSize: `${(adapter.limits.maxStorageBufferBindingSize / 1024 / 1024).toFixed(2)} MB`,
     });
 
+    // Build required features list
+    const requiredFeatures: string[] = [];
+    if (canSubgroups) {
+        requiredFeatures.push('subgroups');
+    }
+
     // Request maximum limits supported by the adapter for large tensor operations
     const device = await adapter.requestDevice({
+        requiredFeatures: requiredFeatures as any,
         requiredLimits: {
             maxStorageBuffersPerShaderStage: adapter.limits.maxStorageBuffersPerShaderStage,
             maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -303,7 +303,15 @@ export function getKernelShaderCode(
 ): string {
     const [configdShader, env] = configShader(spec, config);
 
-    let shaderCodeParts: string[] = ["// " + spec.name + " kernel"];
+    let shaderCodeParts: string[] = [];
+
+    // Check if shader uses subgroup operations and add enable directive
+    if (configdShader.includes("subgroup")) {
+        shaderCodeParts.push("enable subgroups;");
+        shaderCodeParts.push("");
+    }
+
+    shaderCodeParts.push("// " + spec.name + " kernel");
     shaderCodeParts.push(`struct ${spec.name}Parameters {`);
     for (let i = 0; i < spec.parameters.length; i++) {
         let parameter = spec.parameters[i];
@@ -364,13 +372,28 @@ export function getKernelShaderCode(
         );
         head = ", ";
     }
+    if (configdShader.includes("workgroup_id")) {
+        shaderCodeParts.push(
+            `    ${head}@builtin(workgroup_id) workgroup_id: vec3u`
+        );
+        head = ", ";
+    }
+    if (configdShader.includes("subgroup_invocation_id")) {
+        shaderCodeParts.push(
+            `    ${head}@builtin(subgroup_invocation_id) subgroup_invocation_id: u32`
+        );
+        head = ", ";
+    }
+    if (configdShader.includes("subgroup_size")) {
+        shaderCodeParts.push(
+            `    ${head}@builtin(subgroup_size) subgroup_size: u32`
+        );
+        head = ", ";
+    }
     shaderCodeParts.push(`    ) {`);
     shaderCodeParts.push("    " + configdShader);
     shaderCodeParts.push("}");
     const shaderCode = shaderCodeParts.join("\n");
-    // if (spec.name === "mean_dim") {
-    //     console.log(shaderCode);
-    // }
     return shaderCode;
 }
 

--- a/src/ops_artisanal.ts
+++ b/src/ops_artisanal.ts
@@ -2,7 +2,7 @@ import { shouldCreateGradient } from "./autograd";
 import { Tensor } from "./tensor";
 import type { Deviceish } from "./device";
 import type { Dtype } from "./dtype";
-import { slice } from "./custom/WebGPUKernels";
+import { slice, permute } from "./custom/WebGPUKernels";
 import {
     broadcastBatchedMatmul,
     contiguousStridedShape,
@@ -98,15 +98,15 @@ export function cat(inputs: Tensor[], dim: number = 0): Tensor {
     const device = inputs[0].device;
 
     // Log large concatenations for debugging
-    const outputSize = outputShape.reduce((a, b) => a * b, 1) * 4; // assuming float32
-    if (outputSize > 100 * 1024 * 1024) { // > 100MB
-        console.warn(`[CAT] Large concatenation: ${inputs.length} inputs, output shape [${outputShape}], ` +
-                     `output size: ${(outputSize / 1024 / 1024).toFixed(2)} MB, dim: ${dim}`);
-        inputs.forEach((t, i) => {
-            const inputSize = t.shape.reduce((a, b) => a * b, 1) * 4;
-            console.warn(`  Input ${i}: shape [${t.shape}], size: ${(inputSize / 1024 / 1024).toFixed(2)} MB`);
-        });
-    }
+    // const outputSize = outputShape.reduce((a, b) => a * b, 1) * 4; // assuming float32
+    // if (outputSize > 100 * 1024 * 1024) { // > 100MB
+    //     console.warn(`[CAT] Large concatenation: ${inputs.length} inputs, output shape [${outputShape}], ` +
+    //                  `output size: ${(outputSize / 1024 / 1024).toFixed(2)} MB, dim: ${dim}`);
+    //     inputs.forEach((t, i) => {
+    //         const inputSize = t.shape.reduce((a, b) => a * b, 1) * 4;
+    //         console.warn(`  Input ${i}: shape [${t.shape}], size: ${(inputSize / 1024 / 1024).toFixed(2)} MB`);
+    //     });
+    // }
 
     // Debug: Check device type
 
@@ -343,49 +343,82 @@ export function conv2d(
         const outputHeight = Math.floor((input.shape[2] + 2 * padH - weight.shape[2]) / strideH) + 1;
         const outputWidth = Math.floor((input.shape[3] + 2 * padW - weight.shape[3]) / strideW) + 1;
 
-        const params = {
-            batchSize: input.shape[0],
-            inputChannels: input.shape[1],
-            outputChannels: weight.shape[0],
-            inputHeight: input.shape[2],
-            inputWidth: input.shape[3],
-            kernelHeight: weight.shape[2],
-            kernelWidth: weight.shape[3],
-            outputHeight: outputHeight,
-            outputWidth: outputWidth,
-            padH: padH,
-            padW: padW,
-            strideH: strideH,
-            strideW: strideW,
-        };
+        const batchSize = input.shape[0];
+        const inputChannels = input.shape[1];
+        const outputChannels = weight.shape[0];
+        const kernelHeight = weight.shape[2];
+        const kernelWidth = weight.shape[3];
 
-        // WORKAROUND: WebGPU 64-channel execution limit
-        // Use splitChannelOperation to handle any number of output channels
+        // ========== Im2col + GEMM Approach with Input Channel Splitting ==========
+        // Split input channels to keep im2col buffer under 200MB (reduced for memory optimization)
+        // im2col output: [B * H_out * W_out, C_in_split * K_H * K_W]
+        const maxInputChannels = Math.max(1, Math.floor(200000000 / (batchSize * outputHeight * outputWidth * kernelHeight * kernelWidth * 4)));
+
         const result = splitChannelOperation(
-            params.outputChannels,
+            outputChannels,
             1, // Channel dimension in NCHW format
-            (startChannel: number, endChannel: number) => {
-                const channelCount = endChannel - startChannel;
+            (startOutChannel: number, endOutChannel: number) => {
+                const outChannelCount = endOutChannel - startOutChannel;
 
-                // Slice weight tensor: [out_channels, in_channels, kH, kW]
-                const weightSlice = slice(weight, [[startChannel, endChannel], null, null, null]);
+                // Accumulate results across input channel batches
+                let accumulated: Tensor | null = null;
 
-                // Create params for this channel batch
-                const batchParams = { ...params, outputChannels: channelCount };
+                for (let ic = 0; ic < inputChannels; ic += maxInputChannels) {
+                    const currentInputChannels = Math.min(maxInputChannels, inputChannels - ic);
 
-                // Run kernel for this channel batch
-                return input.runKernel(
-            "conv2d",
-            { dtype: input.dtype },
-                    batchParams,
-                    [[batchParams.batchSize, channelCount, batchParams.outputHeight, batchParams.outputWidth]],
-                    weightSlice
-        )[0];
+                    // Slice input channels
+                    const inputSlice = slice(input, [null, [ic, ic + currentInputChannels], null, null]);
+
+                    // Step 1: Apply im2col transformation
+                    const im2colParams = {
+                        batchSize: batchSize,
+                        inputChannels: currentInputChannels,
+                        inputHeight: input.shape[2],
+                        inputWidth: input.shape[3],
+                        kernelHeight: kernelHeight,
+                        kernelWidth: kernelWidth,
+                        outputHeight: outputHeight,
+                        outputWidth: outputWidth,
+                        padH: padH,
+                        padW: padW,
+                        strideH: strideH,
+                        strideW: strideW,
+                        dilationH: 1,
+                        dilationW: 1,
+                    };
+
+                    // Use im2col_transposed to avoid expensive transpose operation
+                    const im2colOutput = inputSlice.runKernel(
+                        "im2col_transposed",
+                        { dtype: inputSlice.dtype },
+                        im2colParams,
+                        [[currentInputChannels * kernelHeight * kernelWidth, batchSize * outputHeight * outputWidth]],
+                    )[0];
+
+                    // Step 2: Slice and reshape weight
+                    const weightSlice = slice(weight, [[startOutChannel, endOutChannel], [ic, ic + currentInputChannels], null, null]);
+                    const weightReshaped = weightSlice.reshape([outChannelCount, currentInputChannels * kernelHeight * kernelWidth]);
+
+                    // Step 3: GEMM - weight @ im2col^T (already transposed by kernel)
+                    // weight: [C_out, C_in*K*K]
+                    // im2col_transposed: [C_in*K*K, B*H*W]
+                    // result: [C_out, B*H*W]
+                    const partialResult = fastmm(weightReshaped, im2colOutput);
+
+                    // Step 4: Reshape and permute
+                    // [C_out, B*H*W] -> [C_out, B, H, W] -> [B, C_out, H, W]
+                    const resultReshaped = partialResult.reshape([outChannelCount, batchSize, outputHeight, outputWidth]);
+                    const result = permute(resultReshaped, [1, 0, 2, 3]);
+
+                    // Accumulate
+                    accumulated = accumulated === null ? result : accumulated.add(result);
+                }
+
+                return accumulated!;
             }
         );
 
-        // Add bias if provided
-        // WORKAROUND: Use splitChannelOperation for bias addition too (64-channel limit affects .add() operation)
+        // Step 5: Add bias if provided
         const finalResult = bias
             ? splitChannelOperation(
                 bias.shape[0],
@@ -677,7 +710,7 @@ export function matmul(input: Tensor, other: Tensor): Tensor {
     }
     let params: KernelParamsInput = {};
     if (op === "bmm") {
-        console.log('BATCH MULT\n')
+        // console.log('BATCH MULT\n')
         params = {
             batchSize: Math.max(aop.shape[0], bop.shape[0]),
             aRows: aop.shape[1],
@@ -751,7 +784,7 @@ export function mm(input: Tensor, other: Tensor): Tensor {
         bColStride: other.strides[1],
         alpha: 1.0,
     };
-    console.log('mm parameters:',params)
+    // console.log('mm parameters:',params)
     return input.runKernel(
         "mm",
         { resultDtype: input.dtype },
@@ -764,7 +797,7 @@ export function mm(input: Tensor, other: Tensor): Tensor {
     }
 }
 export function fastmm(input: Tensor, other: Tensor): Tensor {
-    console.log('fastmm func\n')
+    // console.log('fastmm func\n')
     if (shouldCreateGradient(input, other)) {
         throw new Error("mm gradient not supported yet");
     } else {
@@ -788,7 +821,7 @@ export function fastmm(input: Tensor, other: Tensor): Tensor {
         bColStride: other.strides[1],       
     };
     // console.log(input.strides)
-    console.log(`CYP: ${input.shape}, ${other.shape}, ${input.strides}, ${other.strides}`);
+    // console.log(`CYP: ${input.shape}, ${other.shape}, ${input.strides}, ${other.strides}`);
     return input.runKernel(
         "fastmm2",
         { resultDtype: input.dtype },


### PR DESCRIPTION
kernel.ts - Subgroup Feature Support
devices.ts - tried to add WebGPU Subgroups Feature

SliceKernel, SliceAssignKernel - tried loop unrolling, and pre-computed strides, but didn't have much improvements

SoftmaxKernel - Subgroup Operations (Warp-level Primitives)
- **Subgroup Operations**
- **Parallel Reduction**
- **Two-level Reduction**
- **Shared Memory**: `sharedMax[8]`, `sharedSum[8]` arrays for inter-subgroup communication (256/32 = 8 subgroups)
- Result : render time improvement was very slight.

kernels_artisanal.ts - New Kernels Added
- **im2col**: Image-to-matrix transformation for convolution
- **im2col_transposed**: transpose of im2col
- Result: improves 5 - 10% of time (0.5-1s for 512x512) which was spent after unet rendering.

